### PR TITLE
list_liked_trips()함수 구현

### DIFF
--- a/frontend/src/components/mypage/StatDetailModal.jsx
+++ b/frontend/src/components/mypage/StatDetailModal.jsx
@@ -5,7 +5,7 @@ const StatDetailModal = ({ show, onHide, title, data = [], loading }) => {
   return (
     <Modal show={show} onHide={onHide} centered scrollable>
       <Modal.Header closeButton className="border-0">
-        <Modal.Title className="fw-bold fs-5">{title} 목록 (최근 5개)</Modal.Title>
+        <Modal.Title className="fw-bold fs-5">{title} 목록</Modal.Title>
       </Modal.Header>
       <Modal.Body className="pt-0">
         {loading ? (
@@ -19,7 +19,7 @@ const StatDetailModal = ({ show, onHide, title, data = [], loading }) => {
               data.map((item, idx) => (
                 <ListGroup.Item key={idx} className="py-3 border-light">
                   <div className="fw-bold text-dark">{item.title || item.name || '제목 없음'}</div>
-                  <div className="text-muted small">{item.description || item.location || '상세 정보가 없습니다.'}</div>
+                  <div className="text-muted small">{item.date || item.description || item.location || '상세 정보가 없습니다.'}</div>
                 </ListGroup.Item>
               ))
             ) : (

--- a/supabase/migrations/20260127000101_list_liked_trips_rpc.sql
+++ b/supabase/migrations/20260127000101_list_liked_trips_rpc.sql
@@ -1,0 +1,100 @@
+-- Create RPC function to get user's liked trips
+-- Similar to list_public_trips but filters by trip_likes for current user
+
+DROP FUNCTION IF EXISTS public.list_liked_trips(int, timestamptz, uuid);
+
+CREATE OR REPLACE FUNCTION list_liked_trips(
+  p_limit int DEFAULT 20,
+  p_cursor_created_at timestamptz DEFAULT NULL,
+  p_cursor_id uuid DEFAULT NULL
+)
+RETURNS TABLE (
+  id uuid,
+  title text,
+  summary text,
+  cover_image_url text,
+  start_date date,
+  end_date date,
+  created_at timestamptz,
+  author_id uuid,
+  author_name text,
+  author_avatar_url text,
+  like_count bigint,
+  bookmark_count bigint,
+  member_count bigint,
+  regions text[],
+  themes text[]
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+STABLE
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  cursor_condition text;
+BEGIN
+  -- Check if user is authenticated
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Authentication required' USING ERRCODE = 'P0001';
+  END IF;
+
+  -- Set cursor condition for pagination
+  IF p_cursor_created_at IS NOT NULL AND p_cursor_id IS NOT NULL THEN
+    cursor_condition := format('(tl.created_at, tl.trip_id) < (%L, %L)', p_cursor_created_at, p_cursor_id);
+  ELSE
+    cursor_condition := 'TRUE';
+  END IF;
+
+  RETURN QUERY EXECUTE format('
+    SELECT
+      t.id,
+      t.title,
+      t.summary,
+      t.cover_image_url,
+      t.start_date,
+      t.end_date,
+      t.created_at,
+      p.id as author_id,
+      COALESCE(p.full_name, p.username) as author_name,
+      p.avatar_url as author_avatar_url,
+      COALESCE(lc.cnt, 0) as like_count,
+      COALESCE(bc.cnt, 0) as bookmark_count,
+      COALESCE(mc.cnt, 0) as member_count,
+      COALESCE(ra.regions, ARRAY[]::text[]) as regions,
+      COALESCE(ta.themes, ARRAY[]::text[]) as themes
+    FROM trip_likes tl
+    JOIN trips t ON t.id = tl.trip_id
+    JOIN profiles p ON p.id = t.created_by
+    LEFT JOIN (
+      SELECT trip_id, COUNT(*) as cnt FROM trip_likes GROUP BY trip_id
+    ) lc ON lc.trip_id = t.id
+    LEFT JOIN (
+      SELECT trip_id, COUNT(*) as cnt FROM trip_bookmarks GROUP BY trip_id
+    ) bc ON bc.trip_id = t.id
+    LEFT JOIN (
+      SELECT trip_id, COUNT(*) as cnt FROM trip_members GROUP BY trip_id
+    ) mc ON mc.trip_id = t.id
+    LEFT JOIN (
+      SELECT tr.trip_id, array_agg(reg.name ORDER BY tr.created_at) as regions
+      FROM trip_regions tr
+      JOIN regions reg ON reg.id = tr.region_id
+      GROUP BY tr.trip_id
+    ) ra ON ra.trip_id = t.id
+    LEFT JOIN (
+      SELECT tt.trip_id, array_agg(thm.name ORDER BY tt.created_at) as themes
+      FROM trip_themes tt
+      JOIN themes thm ON thm.id = tt.theme_id
+      GROUP BY tt.trip_id
+    ) ta ON ta.trip_id = t.id
+    WHERE tl.user_id = $1
+      AND %s
+    ORDER BY tl.created_at DESC, tl.trip_id DESC
+    LIMIT $2
+  ', cursor_condition)
+  USING v_user_id, p_limit;
+END;
+$$;
+
+-- Create index for better pagination performance (if not already exists)
+CREATE INDEX IF NOT EXISTS idx_trip_likes_user_created_at 
+  ON public.trip_likes(user_id, created_at DESC, trip_id DESC);


### PR DESCRIPTION
## 🔎 What

-# feat: 마이페이지 "좋아요" 기능 구현

데이터베이스 (Supabase)
- **새 파일:** `supabase/migrations/20260127000101_list_liked_trips_rpc.sql`
  - `list_liked_trips()` RPC 함수 추가
  - 기능:
    - 현재 사용자가 좋아요한 여행 조회
    - 최신순 정렬
    - 커서 기반 페이지네이션 지원

 `frontend/src/services/trips.service.js`
- `listLikedTrips(params)` 함수 추가
  - RPC 호출을 통해 좋아요한 여행 조회
  - 응답 데이터 변환 (`mapRowToCard` 재사용)
  - 다음 페이지 커서 계산

 `frontend/src/pages/MyPage.jsx`
- `import { listLikedTrips } from '../services/trips.service'` 추가
- `handleStatClick()` 함수 개선:
  - "찜" 클릭 시 `listLikedTrips()` RPC 호출
  - 조회된 여행을 간단한 형식으로 변환 (제목, 날짜)
  - 로딩 상태 처리
  - 에러 처리



## 🔄 동작 흐름

 

## 🔗 Issue

- Closes: #139 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?
