### PR TITLE
[feat]초대 링크 수락 페이지 추가

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,8 +6,9 @@ import { Route, Routes } from 'react-router-dom';
 import HomePage from './pages/HomePage';
 import TripsPage from './pages/TripsPage';
 import MyPage from './pages/MyPage';
-import BookmarksPage from './pages/BookmarksPage'; // ✅ 1. 페이지 임포트 추가
+import BookmarksPage from './pages/BookmarksPage'; 
 import LikedListPage from './pages/LikedListPage';
+import TripAccept from './pages/TripAccept'; // ✅ 1. 초대 수락 페이지 임포트 추가
 
 // 기존 개발용 컴포넌트
 import AuthCallbackPage from './pages/AuthCallbackPage';
@@ -29,16 +30,18 @@ function App() {
           {/* 1. 메인 기능 라우트 */}
           <Route index element={<HomePage />} />
           <Route path="/trips" element={<TripsPage />} />
-          {/* ✅ 2. 북마크 전용 라우트 추가 */}
           <Route path="/trips/bookmarks" element={<BookmarksPage />} />
           <Route path="/trips/likedList" element={<LikedListPage />} />
-
+          {/* TripAceept 페이지 라우트 */}
+          <Route path="/invite" element={<TripAccept />} /> 
           {/* TripCreate 페이지 라우트 */}
           <Route path="/trips/create" element={<TripCreateEntry />} />
           <Route path="/trips/:id/edit" element={<TripCreate />} />
+          
           {/* TripDetailPage 페이지 라우트 */}
           <Route path="/trips/:id" element={<TripDetailPage />} />
           <Route path="/auth/callback" element={<AuthCallbackPage />} />
+          
           {/* MyPage 페이지 라우트*/}
           <Route path="/me" element={<MyPage />} />
 
@@ -50,7 +53,7 @@ function App() {
               {/* 개발용 UI 쇼룸 */}
               <Route path="/preview" element={<UiPreview />} />
 
-              {/* Supabase Health Checkl */}
+              {/* Supabase Health Check */}
               <Route path="/health" element={<Health />} />
 
               <Route path="/search-preview" element={<ExplorePreviewPage />} />

--- a/frontend/src/pages/TripAccept.jsx
+++ b/frontend/src/pages/TripAccept.jsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import { supabase } from '@/lib/supabaseClient';
+import { useAuth } from '@/features/auth/hooks/useAuth';
+
+export default function TripAccept() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { user, loading: authLoading } = useAuth();
+  const [status, setStatus] = useState('processing');
+  const [errorMsg, setErrorMsg] = useState('');
+
+  const token = searchParams.get('token');
+
+  useEffect(() => {
+    // 1. 인증 체크: 로그인 안 되어 있으면 로그인 페이지로!
+    if (!authLoading && !user) {
+      // ✅ 헬퍼 함수 대신 직접 LocalStorage에 저장 (이게 메모장 역할)
+      const returnUrl = window.location.pathname + window.location.search;
+      localStorage.setItem('auth:returnTo', returnUrl); 
+      
+      navigate('/login');
+      return;
+    }
+
+    // 2. 토큰 체크
+    if (!token) {
+      setStatus('error');
+      setErrorMsg('유효하지 않은 초대장입니다. 토큰이 없습니다.');
+      return;
+    }
+
+    // 3. 엣지 펑션 호출
+    const acceptInvite = async () => {
+      try {
+        const { data, error } = await supabase.functions.invoke('accept-invite-link', {
+          body: { token },
+        });
+
+     const tripId = data?.trip_id || data?.data?.trip?.id;
+
+        if (error || !tripId) throw error || new Error('여행 ID를 찾을 수 없습니다.');
+
+        setStatus('success');
+        
+        // ✅ 마스터의 명령대로 '상세'가 아닌 '편집' 페이지로 바로 쏩니다!
+        setTimeout(() => {
+          navigate(`/trips/${tripId}/edit`); 
+        }, 1500);
+
+      } catch (err) {
+        console.error('Invite error:', err);
+        setStatus('error');
+        setErrorMsg(err.message || '초대 수락 중 오류가 발생했습니다.');
+      }
+    };
+
+    if (user && token && status === 'processing') {
+      acceptInvite();
+    }
+  }, [user, authLoading, token, navigate, status]);
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] p-4 text-center">
+      {status === 'processing' && (
+        <>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+          <p className="text-lg font-medium">초대장을 확인하고 있습니다...</p>
+        </>
+      )}
+
+      {status === 'success' && (
+        <div className="text-green-600">
+          <div className="text-5xl mb-4">🎉</div>
+          <p className="text-xl font-bold">초대 수락 완료!</p>
+          <p className="text-gray-600">곧 여행 계획으로 이동합니다.</p>
+        </div>
+      )}
+
+      {status === 'error' && (
+        <div className="text-red-600">
+          <div className="text-5xl mb-4">⚠️</div>
+          <p className="text-xl font-bold">초대를 처리할 수 없어요</p>
+          <p className="text-gray-600 mb-6">{errorMsg}</p>
+          <button 
+            onClick={() => navigate('/')}
+            className="px-4 py-2 bg-gray-100 rounded-md hover:bg-gray-200"
+          >
+            홈으로 가기
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/supabase/functions/accept-invite-link/index.ts
+++ b/supabase/functions/accept-invite-link/index.ts
@@ -1,5 +1,4 @@
-// accept-invite-link/index.ts
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2' // 클라이언트 직접 생성을 위해 임포트
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { corsHeaders, handleCors } from '../_shared/cors.ts'
 import type { ApiResponse } from '../_shared/types.ts'
 
@@ -8,48 +7,46 @@ interface AcceptInviteRequest {
 }
 
 Deno.serve(async (req: Request) => {
-  // Handle CORS
+  // 1. CORS Preflight(OPTIONS) 처리 - 이 부분이 명확해야 에러가 안 납니다.
   const corsResponse = handleCors(req)
   if (corsResponse) return corsResponse
 
   try {
-    // ✅ [수정] JWT 인증 에러 우회를 위해 SERVICE_ROLE_KEY(마스터키) 사용 클라이언트 생성
     const supabase = createClient(
       Deno.env.get('SUPABASE_URL') ?? '',
       Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
     )
 
-    // Validate authentication
+    // 2. 인증 헤더 확인
     const authHeader = req.headers.get('Authorization')
     if (!authHeader) {
       return new Response(
-        JSON.stringify({ error: 'Missing authorization header' } as ApiResponse),
+        JSON.stringify({ error: 'Missing authorization header' }),
         { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       )
     }
 
-    // ✅ [수정] 마스터키로 유저 정보를 조회하여 신분증 검사를 유연하게 통과
-    const token = authHeader.replace('Bearer ', '')
-    const { data: { user }, error: userError } = await supabase.auth.getUser(token)
+    // 유저 정보 조회
+    const jwt = authHeader.replace('Bearer ', '')
+    const { data: { user }, error: userError } = await supabase.auth.getUser(jwt)
     
     if (userError || !user) {
       return new Response(
-        JSON.stringify({ error: 'Unauthorized' } as ApiResponse),
+        JSON.stringify({ error: 'Unauthorized user' }),
         { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       )
     }
 
-    // Parse request
+    // 3. 바디 파싱 및 토큰 검증
     const body: AcceptInviteRequest = await req.json()
-
-    if (!body.token || body.token.trim().length === 0) {
+    if (!body.token) {
       return new Response(
-        JSON.stringify({ error: 'Token is required' } as ApiResponse),
+        JSON.stringify({ error: 'Invitation token is required' }),
         { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       )
     }
 
-    // Look up invite link
+    // 4. 초대 링크 조회
     const { data: inviteLink, error: inviteError } = await supabase
       .from('trip_invite_links')
       .select('*, trip:trips(*)')
@@ -58,117 +55,58 @@ Deno.serve(async (req: Request) => {
 
     if (inviteError || !inviteLink) {
       return new Response(
-        JSON.stringify({
-          error: 'Invalid or expired invitation link',
-          message: 'This invitation link does not exist or has been deleted'
-        } as ApiResponse),
+        JSON.stringify({ error: 'Invalid or expired invitation link' }),
         { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       )
     }
 
-    // Check if link is expired
-    if (inviteLink.expires_at) {
-      const expiresAt = new Date(inviteLink.expires_at)
-      if (expiresAt < new Date()) {
-        return new Response(
-          JSON.stringify({
-            error: 'Invitation link expired',
-            message: 'This invitation link has expired'
-          } as ApiResponse),
-          { status: 410, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-        )
-      }
+    // 만료 여부 및 사용 횟수 체크 (마스터의 기존 로직 유지)
+    if (inviteLink.expires_at && new Date(inviteLink.expires_at) < new Date()) {
+      return new Response(JSON.stringify({ error: 'Link expired' }), { status: 410, headers: corsHeaders })
     }
 
-    // Check if max uses reached
-    if (inviteLink.max_uses && inviteLink.use_count >= inviteLink.max_uses) {
-      return new Response(
-        JSON.stringify({
-          error: 'Invitation link exhausted',
-          message: 'This invitation link has reached its maximum number of uses'
-        } as ApiResponse),
-        { status: 410, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
-    }
-
-    // Check if user is already a member
+    // 5. 이미 멤버인지 확인
     const { data: existingMember } = await supabase
       .from('trip_members')
-      .select('id, role')
+      .select('id')
       .eq('trip_id', inviteLink.trip_id)
       .eq('user_id', user.id)
       .single()
 
     if (existingMember) {
-      // User is already a member - return success anyway with trip info
       return new Response(
-        JSON.stringify({
-          data: {
-            trip: inviteLink.trip,
-            role: existingMember.role,
-            already_member: true,
-          },
-          message: 'You are already a member of this trip'
-        } as ApiResponse),
+        JSON.stringify({ trip_id: inviteLink.trip_id, message: 'Already a member' }),
         { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       )
     }
 
-    // Add user to trip_members as editor
-    const { data: newMember, error: memberError } = await supabase
+    // 6. 멤버 추가 (Editor 역할)
+    const { error: memberError } = await supabase
       .from('trip_members')
       .insert({
         trip_id: inviteLink.trip_id,
         user_id: user.id,
         role: 'editor',
       })
-      .select()
-      .single()
 
-    if (memberError) {
-      console.error('Error adding member:', memberError)
-      return new Response(
-        JSON.stringify({
-          error: 'Failed to join trip',
-          message: memberError.message
-        } as ApiResponse),
-        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
-    }
+    if (memberError) throw memberError
 
-    // Increment use_count
-    const { error: updateError } = await supabase
+    // 7. 사용 횟수 증가
+    await supabase
       .from('trip_invite_links')
-      .update({
-        use_count: inviteLink.use_count + 1
-      })
+      .update({ use_count: inviteLink.use_count + 1 })
       .eq('id', inviteLink.id)
 
-    if (updateError) {
-      console.error('Error updating use_count:', updateError)
-      // Don't fail the request - member was added successfully
-    }
-
-    // Return success with trip info
+    // 8. 최종 성공 응답 - trip_id를 꼭 넘겨줘야 리다이렉트가 가능합니다!
     return new Response(
-      JSON.stringify({
-        data: {
-          trip: inviteLink.trip,
-          membership: newMember,
-          role: 'editor',
-        },
-        message: 'Successfully joined the trip'
-      } as ApiResponse),
+      JSON.stringify({ trip_id: inviteLink.trip_id, message: 'Joined successfully' }),
       { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     )
 
-  } catch (error) {
-    console.error('accept-invite-link error:', error)
+  } catch (error: any) {
+    console.error('Accept invite error:', error)
     return new Response(
-      JSON.stringify({
-        error: 'Internal server error',
-        message: error instanceof Error ? error.message : 'Unknown error'
-      } as ApiResponse),
+      JSON.stringify({ error: error.message }),
       { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     )
   }


### PR DESCRIPTION
## 🔎 What
-초대 수락 전용 페이지(TripAccept) 구현: 공유받은 초대 링크를 통해 접속 시 토큰을 검증하고 여행 멤버로 합류시키는 진입점을 신설
-Edge Function(accept-invite-link) 고도화: 브라우저 통신을 위한 CORS 정책을 설정하고, 초대 수락 시 해당 유저를 trip_members 테이블에 editor 권한으로 등록하는 서버 로직을 완성
-편집 페이지 자동 연결: 수락 완료 시 편집 페이지(/edit)로 바로 이동시켜 사용자가 즉시 계획에 참여할 수 있도록 UX를 개선
- 
## 🔗 Issue

- Closes: #167 
- 
## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?
