### PR TITLE
feat: complete member management (transfer owner, remove member) 

### DIFF
--- a/frontend/src/components/trip-create/TripMemberPicker.jsx
+++ b/frontend/src/components/trip-create/TripMemberPicker.jsx
@@ -1,76 +1,88 @@
 import React from 'react';
 
-// Member list with owner badge and action buttons.
+// Member list with separate sections for Owner and Crew
 const TripMemberPicker = ({
   members,
   onOpenTransfer,
   onRemoveMember,
   canManageMembers,
-  onInvite, // 👈 [1. 추가] 부모(Page)에서 내려준 함수 받기
+  onInvite,
 }) => {
-  const totalCount = members ? members.length : 0;
+  // [1단계] 데이터 분리하기 (filter 사용)
+  const safeMembers = members || [];
+  const owners = safeMembers.filter((m) => m.isOwner); // 방장 그룹
+  const crew = safeMembers.filter((m) => !m.isOwner);  // 일반 팀원 그룹
 
   return (
     <div className="trip-member-picker">
-      <div className="trip-member-header">
-        <span className="trip-member-header-icon" aria-hidden="true">
-          <svg viewBox="0 0 24 24" width="24" height="24">
-            <circle cx="8" cy="8" r="3" />
-            <circle cx="16" cy="8" r="3" />
-            <path d="M3 20c0-3 3-5 5-5s5 2 5 5" />
-            <path d="M11 20c0-2 2-4 5-4s5 2 5 4" />
-          </svg>
-        </span>
-        참여자 ({totalCount})
-      </div>
-      <ul className="trip-group-list">
-        {members && members.map((member) => {
-          const isOwner = member.isOwner;
-          return (
+      
+      {/* --- [섹션 1] 👑 방장 (Owner) --- */}
+      <div className="trip-member-section">
+        <div className="trip-member-header">
+          <span className="trip-member-header-icon">👑</span>
+          그룹장
+        </div>
+        <ul className="trip-group-list">
+          {owners.map((member) => (
             <li key={member.id} className="trip-member-item">
-              <span className="trip-member-name">
-                {isOwner && (
-                  <span className="trip-member-role" aria-label="그룹장">
-                    <svg viewBox="0 0 24 24" width="16" height="16">
-                      <path d="M4 18h16l-2-9-4 4-2-6-2 6-4-4-2 9z" />
-                      <path d="M4 18h16v2H4z" />
-                    </svg>
-                  </span>
-                )}
+              <span className="trip-member-name owner-highlight">
                 {member.name}
               </span>
-              {canManageMembers && (
-                <span
-                  className={`trip-member-actions${isOwner ? ' is-hidden' : ''}`}
-                >
-                  {!isOwner && (
-                    <>
-                      <button
-                        className="trip-member-icon-btn"
-                        type="button"
-                        aria-label="그룹장 양도"
-                        onClick={() => onOpenTransfer?.(member.id)}
-                      >
-                        ⇄
-                      </button>
-                      <button
-                        className="trip-member-icon-btn"
-                        type="button"
-                        aria-label="내보내기"
-                        onClick={() => onRemoveMember?.(member.id)}
-                      >
-                        ↗
-                      </button>
-                    </>
-                  )}
-                </span>
-              )}
+              {/* 방장은 내보내기 버튼 없음 */}
             </li>
-          );
-        })}
-      </ul>
-      
-      {/* 2. [핵심] 버튼 클릭 시 onInvite 실행 연결 */}
+          ))}
+        </ul>
+      </div>
+
+      <div className="trip-member-divider" /> {/* 구분선 (CSS 필요 시) */}
+
+      {/* --- [섹션 2] 👥 팀원 (Crew) --- */}
+      <div className="trip-member-section">
+        <div className="trip-member-header">
+          <span className="trip-member-header-icon">👥</span>
+          참여자 ({crew.length})
+        </div>
+        
+        {crew.length === 0 ? (
+          <div className="trip-member-empty">
+            아직 참여자가 없습니다.
+          </div>
+        ) : (
+          <ul className="trip-group-list">
+            {crew.map((member) => (
+              <li key={member.id} className="trip-member-item">
+                <span className="trip-member-name">
+                  {member.name}
+                </span>
+                
+                {/* 관리 권한이 있을 때만 버튼 표시 */}
+                {canManageMembers && (
+                  <span className="trip-member-actions">
+                    <button
+                      className="trip-member-icon-btn"
+                      type="button"
+                      title="그룹장 위임"
+                      onClick={() => onOpenTransfer?.(member.id)}
+                    >
+                      ⇄
+                    </button>
+                    <button
+                      className="trip-member-icon-btn remove-btn"
+                      type="button"
+                      title="내보내기"
+                      onClick={() => onRemoveMember?.(member.id)}
+                    >
+                      ✕
+                    </button>
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* 초대 버튼 */}
       <button 
         className="trip-group-invite" 
         type="button"

--- a/frontend/src/pages/trip-create.css
+++ b/frontend/src/pages/trip-create.css
@@ -276,23 +276,11 @@
 .trip-map-main-container {
   width: 100%;
   height: 100%;
-  position: absolute; /* 버튼들 아래에 깔리도록 설정 */
+  position: absolute;
   top: 0;
   left: 0;
-  z-index: 1; /* 버튼(z-index: 2)보다 낮게 설정 */
+  z-index: 1;
 }
-
-/* .trip-create-map-inner::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background-image:
-    radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.45), transparent 55%),
-    radial-gradient(circle at 80% 30%, rgba(255, 255, 255, 0.35), transparent 50%),
-    linear-gradient(135deg, #dfe7ef 0%, #cdd8e5 45%, #b8c7d9 100%);
-  background-size: cover;
-  background-position: center;
-} */
 
 .trip-map-overlay {
   position: absolute;
@@ -773,7 +761,7 @@
   margin: -8px 0 4px 0;
 }
 
-/* 번호 배지 스타일 (Detail 페이지와 일치) */
+/* 번호 배지 스타일 */
 .trip-schedule-number {
   display: flex;
   justify-content: center;
@@ -1142,115 +1130,122 @@
   cursor: not-allowed;
 }
 
-/* Member picker */
+/* ========================================= */
+/* ✅ Member picker (수정된 부분)           */
+/* ========================================= */
 .trip-member-picker {
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding-top: 6px;
-  align-items: center;
+  gap: 20px;
+  padding: 10px 4px;
+}
+
+.trip-member-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .trip-member-header {
+  font-size: 13px;
+  font-weight: 700;
+  color: #888;
+  padding-left: 4px;
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-weight: 700;
-  justify-content: center;
-  width: 100%;
-}
-
-.trip-member-header-icon svg {
-  width: 18px;
-  height: 18px;
-  fill: none;
-  stroke: #111;
-  stroke-width: 1.8;
-  stroke-linecap: round;
-  stroke-linejoin: round;
+  gap: 6px;
 }
 
 .trip-group-list {
   list-style: none;
   padding: 0;
   margin: 0;
-  width: 100%;
-  max-width: 200px;
-  display: grid;
-  gap: 10px;
-  font-size: 0.9rem;
-  justify-items: center;
-  margin-left: auto;
-  margin-right: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .trip-member-item {
-  position: relative;
-  min-height: 24px;
-  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  background-color: #f8f9fa;
+  border: 1px solid #eee;
+  border-radius: 10px;
+  min-height: 44px;
 }
 
 .trip-member-name {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-weight: 600;
-  white-space: nowrap;
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
+  font-size: 14px;
+  font-weight: 500;
+  color: #333;
 }
 
-.trip-member-role {
-  width: 16px;
-  display: inline-flex;
-  justify-content: center;
-  position: absolute;
-  left: -22px;
-}
-
-.trip-member-role svg {
-  width: 16px;
-  height: 16px;
-  fill: none;
-  stroke: #111;
-  stroke-width: 1.8;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
-
-.trip-member-actions {
-  display: inline-flex;
-  gap: 8px;
-  align-items: center;
-  position: absolute;
-  right: 0;
-}
-
-.trip-member-actions.is-hidden {
-  visibility: hidden;
-}
-
-.trip-member-icon-btn {
-  border: none;
-  background: transparent;
-  font-size: 0.85rem;
-  line-height: 1;
-  padding: 0;
-  cursor: pointer;
+.trip-member-name.owner-highlight {
+  font-weight: 700;
   color: #111;
 }
 
-.trip-group-invite {
-  border: none;
-  background: #111;
-  color: #fff;
-  border-radius: 10px;
-  padding: 10px 20px;
-  font-weight: 700;
-  align-self: center;
-  min-width: 140px;
+.trip-member-actions {
+  display: flex;
+  gap: 6px;
 }
+
+.trip-member-icon-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 1px solid #e5e7eb;
+  background-color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 12px;
+  color: #666;
+  transition: all 0.2s;
+}
+
+.trip-member-icon-btn:hover {
+  background-color: #fff;
+  border-color: #bbb;
+  transform: translateY(-1px);
+}
+
+.trip-member-icon-btn.remove-btn:hover {
+  background-color: #fff5f5;
+  border-color: #ffc9c9;
+  color: #fa5252;
+}
+
+.trip-group-invite {
+  width: 100%;
+  padding: 12px;
+  margin-top: 10px;
+  background-color: #111;
+  color: white;
+  border: none;
+  border-radius: 10px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.trip-group-invite:hover {
+  opacity: 0.9;
+}
+
+.trip-member-empty {
+  font-size: 13px;
+  color: #adb5bd;
+  text-align: center;
+  padding: 15px 0;
+  background-color: #f8f9fa;
+  border: 1px dashed #dee2e6;
+  border-radius: 8px;
+}
+/* ========================================= */
 
 @media (max-width: 768px) {
   .trip-create {

--- a/frontend/src/services/trip-members.service.js
+++ b/frontend/src/services/trip-members.service.js
@@ -2,19 +2,24 @@ import { supabase } from '@/lib/supabaseClient';
 import { unwrap, isConflictError } from '@/services/_core/errors';
 
 /**
- * Update a trip member role (owner/editor).
- * Uses Edge Function: update-trip-member-role
+ * [UPDATE] 멤버 권한 변경 (RPC 사용)
+ * Edge Function 대신 RPC를 사용하여 RLS 문제를 회피합니다.
  */
 export async function updateTripMemberRole({ tripId, memberId, role }) {
-  const result = await supabase.functions.invoke('update-trip-member-role', {
-    body: { tripId, memberId, role },
+  console.log("🚀 [Service] 권한 변경 요청 (RPC):", { tripId, memberId, role });
+
+  // Edge Function 대신 새로 만든 RPC 함수 호출
+  const result = await supabase.rpc('rpc_update_member_role', {
+    p_trip_id: tripId,
+    p_member_id: memberId,
+    p_new_role: role,
   });
+
   return unwrap(result, 'tripMembers.updateTripMemberRole');
 }
 
 /**
- * Fetch trip members with roles.
- * Uses RPC: rpc_trip_members(p_trip_id uuid)
+ * [READ] 여행 참여자 목록 조회
  */
 export async function getTripMembers({ tripId }) {
   const result = await supabase.rpc('rpc_trip_members', {
@@ -23,18 +28,27 @@ export async function getTripMembers({ tripId }) {
   return unwrap(result, 'tripMembers.getTripMembers');
 }
 
+/**
+ * [CREATE] 멤버 추가
+ */
 export async function upsertTripMember({ tripId, userId, role }) {
-  const result = await supabase.rpc('rpc_upsert_trip_member', {
+  const result = await supabase
+    .from('trip_members')
+    .upsert(
+      { trip_id: tripId, user_id: userId, role },
+      { onConflict: 'trip_id,user_id' }
+    );
+  return unwrap(result, 'tripMembers.upsertTripMember');
+}
+
+/**
+ * [DELETE] 멤버 내보내기 (강퇴)
+ * RPC: rpc_delete_member
+ */
+export async function deleteTripMember({ tripId, memberId }) {
+  const result = await supabase.rpc('rpc_delete_member', {
     p_trip_id: tripId,
-    p_user_id: userId,
-    p_role: role,
+    p_member_id: memberId,
   });
-  try {
-    return unwrap(result, 'tripMembers.upsertTripMember');
-  } catch (error) {
-    if (isConflictError(error)) {
-      return null;
-    }
-    throw error;
-  }
+  return unwrap(result, 'tripMembers.deleteTripMember');
 }


### PR DESCRIPTION

## 🔎 What
1. 멤버 목록 UI/UX 전면 개편
참여자 목록을 **👑 그룹장(Owner)**과 👥 참여자(Participants) 섹션으로 분리하여 위계를 명확히 했음
기존의 불안정한 레이아웃을 왼쪽 정렬된 카드형 리스트로 변경하고, 관리 버튼(위임, 강퇴)을 우측에 배치하여 사용성을 높임

2. 멤버 관리 기능 구현 (RPC 적용)
그룹장 위임 (Transfer Owner):
-rpc_update_member_role 함수를 구현하여, 새로운 그룹장 지정 시 기존 그룹장은 자동으로 에디터로 강등되도록 로직을 완성
멤버 내보내기 (Remove Member):
-rpc_delete_member 함수를 통해 그룹장이 특정 멤버를 여행에서 제외하는 기능을 구현
## 🔗 Issue

- Closes: #199 
- 
## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?
